### PR TITLE
Changes row count from str to int

### DIFF
--- a/cmd/row_count.go
+++ b/cmd/row_count.go
@@ -23,7 +23,7 @@ var (
 
 type RowCount struct {
 	Table string `json:"Table"`
-	Rows  string `json:"Rows"`
+	Rows  int    `json:"Rows"`
 }
 
 type connection struct {
@@ -76,10 +76,13 @@ func check_rows_in_db(source_creds vcap.Credentials) {
 	for _, joined_tables := range strings.Split(joined_tables, "\n") {
 		if joined_tables != "" {
 			s := strings.Split(joined_tables, " ")
-			rows = append(rows, &RowCount{Table: s[0], Rows: s[1]})
+			rows_as_int, err := strconv.Atoi(s[1])
+			if err != nil {
+				rows_as_int = -1
+			}
+			rows = append(rows, &RowCount{Table: s[0], Rows: rows_as_int})
 		}
 	}
-
 	// Raw json object of {"Table":"table_name","Rows":"#"}
 	raw, _ := json.Marshal(connection{RowsCountConnection: rows})
 	logging.Logger.Printf("%s", raw)


### PR DESCRIPTION
The JSON structure was storing row counts as strings; this converts it to `int`s.

In other words, it converts the record structure from `[string, string]` to `[string, integer]`, so that we can compute over the row counts later if we need to.

Note that if the `Atoi` fails, we will store -1 as the row count.