### PR TITLE
Remove support_cognizantbaseline from static list of tables

### DIFF
--- a/cmd/assets/db_tables.txt
+++ b/cmd/assets/db_tables.txt
@@ -45,7 +45,6 @@ django_session
 support_adminapievent
 support_administrative_key_uuids
 support_cognizantassignment
-support_cognizantbaseline
 users_permission
 users_staffuser
 users_staffuserlog


### PR DESCRIPTION
This table was removed from the application. Backups are silently failing and it looks like we need to remove this table from the list to fix the issue.